### PR TITLE
Fix compatibility with Ruby 3.4-dev

### DIFF
--- a/graphql.gemspec
+++ b/graphql.gemspec
@@ -29,11 +29,10 @@ Gem::Specification.new do |s|
   s.add_development_dependency "benchmark-ips"
   s.add_development_dependency "concurrent-ruby", "~>1.0"
   s.add_development_dependency "memory_profiler"
-  # Remove this limit when minitest-reports is compatible
-  # https://github.com/kern/minitest-reporters/pull/220
-  s.add_development_dependency "minitest", "~> 5.9.0"
-  s.add_development_dependency "minitest-focus", "~> 1.1"
-  s.add_development_dependency "minitest-reporters", "~>1.0"
+
+  s.add_development_dependency "minitest"
+  s.add_development_dependency "minitest-focus"
+  s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "rake"
   s.add_development_dependency 'rake-compiler'
   s.add_development_dependency "rubocop", "1.12" # for Ruby 2.4 enforcement

--- a/lib/graphql/schema/interface.rb
+++ b/lib/graphql/schema/interface.rb
@@ -69,7 +69,11 @@ module GraphQL
             end
           elsif child_class < GraphQL::Schema::Object
             # This is being included into an object type, make sure it's using `implements(...)`
-            backtrace_line = caller(0, 10).find { |line| line.include?("schema/member/has_interfaces.rb") && line.include?("in `implements'")}
+            backtrace_line = caller_locations(0, 10).find do |location|
+              location.base_label == "implements" &&
+                location.path.end_with?("schema/member/has_interfaces.rb")
+            end
+
             if !backtrace_line
               raise "Attach interfaces using `implements(#{self})`, not `include(#{self})`"
             end

--- a/spec/graphql/dataloader_spec.rb
+++ b/spec/graphql/dataloader_spec.rb
@@ -1160,7 +1160,7 @@ describe GraphQL::Dataloader do
       "Nope (FiberErrorSchema::Query.requestAll, nil, {})",
     ]
 
-    assert_equal(nil, res["data"])
+    assert_nil(res["data"])
     assert_equal(expected_errors, context[:errors].sort)
   end
 

--- a/spec/graphql/execution/lazy_spec.rb
+++ b/spec/graphql/execution/lazy_spec.rb
@@ -136,7 +136,7 @@ describe GraphQL::Execution::Lazy do
         }
       }|
 
-      assert_equal(nil, res["data"])
+      assert_nil(res["data"])
       assert_equal 1, res["errors"].length
     end
 

--- a/spec/graphql/non_null_type_spec.rb
+++ b/spec/graphql/non_null_type_spec.rb
@@ -25,7 +25,7 @@ describe "GraphQL::NonNullType" do
       }
       |
       result = Dummy::Schema.execute(query_string)
-      assert_equal(nil, result["data"])
+      assert_nil(result["data"])
       assert_equal([{"message"=>"Cannot return null for non-nullable field DeepNonNull.nonNullInt"}], result["errors"])
     end
 
@@ -41,7 +41,7 @@ describe "GraphQL::NonNullType" do
         assert_equal("Cannot return null for non-nullable field Cow.cantBeNullButIs", err.message)
         assert_equal("Cow", err.parent_type.graphql_name)
         assert_equal("cantBeNullButIs", err.field.name)
-        assert_equal(nil, err.value)
+        assert_nil(err.value)
       end
     end
   end

--- a/spec/graphql/query/context_spec.rb
+++ b/spec/graphql/query/context_spec.rb
@@ -64,7 +64,7 @@ describe GraphQL::Query::Context do
     let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil) }
 
     it "returns returns nil and reports key? => false" do
-      assert_equal(nil, context[:some_key])
+      assert_nil(context[:some_key])
       assert_equal(false, context.key?(:some_key))
       assert_raises(KeyError) { context.fetch(:some_key) }
     end
@@ -74,7 +74,7 @@ describe GraphQL::Query::Context do
     let(:context) { GraphQL::Query::Context.new(query: OpenStruct.new(schema: schema), values: nil, object: nil) }
 
     it "allows you to assign new contexts" do
-      assert_equal(nil, context[:some_key])
+      assert_nil(context[:some_key])
       context[:some_key] = "wow!"
       assert_equal("wow!", context[:some_key])
     end
@@ -396,7 +396,7 @@ describe GraphQL::Query::Context do
       expected_key = :a
       expected_value = :test
 
-      assert_equal(nil, context[expected_key])
+      assert_nil(context[expected_key])
       assert_equal({}, context.to_h)
       refute(context.key?(expected_key))
       assert_raises(KeyError) { context.fetch(expected_key) }

--- a/spec/graphql/query_spec.rb
+++ b/spec/graphql/query_spec.rb
@@ -865,7 +865,7 @@ describe GraphQL::Query do
 
       schema.execute(query, variables: { 'id' => nil })
       assert(expected_args.first.key?(:id))
-      assert_equal(nil, expected_args.first[:id])
+      assert_nil(expected_args.first[:id])
     end
 
     it 'sets argument to [nil] when [null] is passed' do

--- a/spec/graphql/schema/enum_spec.rb
+++ b/spec/graphql/schema/enum_spec.rb
@@ -171,11 +171,11 @@ describe GraphQL::Schema::Enum do
     it "coerces names to underlying values" do
       assert_equal("YAK", enum.coerce_isolated_input("YAK"))
       assert_equal(1, enum.coerce_isolated_input("COW"))
-      assert_equal(nil, enum.coerce_isolated_input("NONE"))
+      assert_nil(enum.coerce_isolated_input("NONE"))
     end
 
     it "coerces invalid names to nil" do
-      assert_equal(nil, enum.coerce_isolated_input("YAKKITY"))
+      assert_nil(enum.coerce_isolated_input("YAKKITY"))
     end
 
     it "coerces result values to value's value" do

--- a/spec/graphql/schema/scalar_spec.rb
+++ b/spec/graphql/schema/scalar_spec.rb
@@ -194,7 +194,7 @@ describe GraphQL::Schema::Scalar do
     end
 
     it "coerces nil into nil" do
-      assert_equal(nil, custom_scalar.coerce_isolated_input(nil))
+      assert_nil(custom_scalar.coerce_isolated_input(nil))
     end
 
     it "coerces input into objects" do

--- a/spec/graphql/subscriptions_spec.rb
+++ b/spec/graphql/subscriptions_spec.rb
@@ -416,13 +416,13 @@ describe GraphQL::Subscriptions do
 
         # Let's see what GraphQL sent over the wire:
         assert_equal({"str" => "Update", "int" => 1}, deliveries["1"][0]["data"]["payload"])
-        assert_equal(nil, deliveries["1"][0]["data"]["event"])
+        assert_nil(deliveries["1"][0]["data"]["event"])
 
         # Trigger another field subscription
         schema.subscriptions.trigger(:event, {}, OpenStruct.new(int: 1))
 
         # Now we should get result for another field
-        assert_equal(nil, deliveries["1"][1]["data"]["payload"])
+        assert_nil(deliveries["1"][1]["data"]["payload"])
         assert_equal({"int" => 1}, deliveries["1"][1]["data"]["event"])
       end
 

--- a/spec/graphql/types/iso_8601_date_spec.rb
+++ b/spec/graphql/types/iso_8601_date_spec.rb
@@ -189,14 +189,14 @@ describe GraphQL::Types::ISO8601Date do
         "parseDateOptional" => nil
       }
       assert_equal(expected_res, res["data"])
-      assert_equal(nil, res["errors"])
+      assert_nil(res["errors"])
 
       res = DateTest::Schema.execute(query_str, context: { raise_type_error: true })
       expected_res = {
         "parseDateOptional" => nil
       }
       assert_equal(expected_res, res["data"])
-      assert_equal(nil, res["errors"])
+      assert_nil(res["errors"])
     end
   end
 


### PR DESCRIPTION
- Backtrace rendering changes, so the `caller` parsing needed to be improved.
- Minitest needed an upgrade.
- Base64 is no longer bundled.